### PR TITLE
Feature: Added two tests for Point to Polynomial (#36)

### DIFF
--- a/linear_algebra/src/polynom_for_points.py
+++ b/linear_algebra/src/polynom_for_points.py
@@ -114,3 +114,7 @@ if __name__ == "__main__":
     print(points_to_polynomial([[1, 3], [2, 6], [3, 11]]))
     print(points_to_polynomial([[1, -3], [2, -6], [3, -11]]))
     print(points_to_polynomial([[1, 5], [2, 2], [3, 9]]))
+    # NEW TEST for row 34: 
+    print(points_to_polynomial([[1, 0], [2, 0], [2, 0], [3, 0]]))  
+    # NEW TEST for row 38:
+    print(points_to_polynomial([[1, 0]]))


### PR DESCRIPTION
Added tests to two of the uncovered lines (35 and 39):

34: if len({tuple(pair) for pair in coordinates}) != len(coordinates): Here I added a test that gives four cordinates, which makes 
      len({tuple(pair) for pair in coordinates}) = 4
      len(coordinates) = 3
      and they are no longer equal

38: if len(set_x) == 1: 
    If there is only one point then we get a straight line, so we use a single coordinate as input to test this.